### PR TITLE
Fix for Bionic running in batch mode on gpg2

### DIFF
--- a/resources/key.rb
+++ b/resources/key.rb
@@ -53,7 +53,8 @@ EOS
 
     cmd = gpg_cmd
     cmd << gpg_opts(new_resource) if new_resource.override_default_keyring
-    cmd << ' --batch'
+    cmd << " --passphrase #{new_resource.passphrase}"
+    cmd << ' --yes --batch --pinentry-mode loopback'
     cmd << " --gen-key #{new_resource.batch_config_file}"
 
     execute 'gpg2: generate' do


### PR DESCRIPTION
### Description

Allows for Ubuntu Bionic to be able converge with the `gpg_key` resource.

In my cookbook, I am referencing it just with:
```
gpg_install
gpg_key 'name' do
  user 'someuser'
end 
```

### Issues Resolved

https://github.com/sous-chefs/gpg/issues/12

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
