### PR TITLE
Fix 404 on documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ end
 
 For further detail please see the documentation for each resource, or the test cookbook for example usage.
 
-- [gpg_install](documentation/resources/install.md)
-- [gpg_key](documentation/resources/key.md)
+- [gpg_install](documentation/resource/install.md)
+- [gpg_key](documentation/resource/key.md)
 - [Test Cookbook](test/fixtures/cookbooks/test/recipes)


### PR DESCRIPTION
### Description

Makes clicking link on readme work

### Issues Resolved

Fixes none currently filed.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
