### PR TITLE
Comment out enforce_idempotency in kitchen.dokken.yml so tests work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,14 @@ jobs:
     strategy:
       matrix:
         os:
-          - 'amazonlinux'
           - 'amazonlinux-2'
-          - 'debian-8'
-          - 'debian-9'
           - 'centos-7'
+          - 'centos-8'
+          - 'debian-9'
+          - 'debian-10'
           - 'ubuntu-1604'
           - 'ubuntu-1804'
+          - 'ubuntu-2004'
         suite:
           - 'default'
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the gpg cookbook.
 ## Unreleased
 
 - Comment out enforce_idempotency in kitchen.dokken.yml so tests work
+- Update/Remove the platforms we test against
 
 ## 1.1.0 (2020-05-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the gpg cookbook.
 
 ## Unreleased
 
+- Comment out enforce_idempotency in kitchen.dokken.yml so tests work
+
 ## 1.1.0 (2020-05-14)
 
 - resolved cookstyle error: resources/install.rb:1:36 convention: `Layout/TrailingWhitespace`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of the gpg cookbook.
 
 - Comment out enforce_idempotency in kitchen.dokken.yml so tests work
 - Update/Remove the platforms we test against
+- Fix support for pinentry_mode on Ubuntu 16.04
 
 ## 1.1.0 (2020-05-14)
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -18,36 +18,31 @@ provisioner:
     treat_deprecation_warnings_as_errors: true
 
 platforms:
-  - name: amazonlinux
-    driver:
-      image: dokken/amazonlinux
-      pid_one_command: /sbin/init
-
   - name: amazonlinux-2
     driver:
       image: dokken/amazonlinux-2
       pid_one_command: /usr/lib/systemd/systemd
-
-  - name: centos-6
-    driver:
-      image: dokken/centos-6
-      pid_one_command: /sbin/init
 
   - name: centos-7
     driver:
       image: dokken/centos-7
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: debian-8
+  - name: centos-8
     driver:
-      image: dokken/debian-8
-      pid_one_command: /sbin/init
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
+      image: dokken/centos-8
+      pid_one_command: /usr/lib/systemd/systemd
 
   - name: debian-9
     driver:
       image: dokken/debian-9
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+
+  - name: debian-10
+    driver:
+      image: dokken/debian-10
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
@@ -62,6 +57,13 @@ platforms:
   - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-18.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+
+  - name: ubuntu-20.04
+    driver:
+      image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -10,8 +10,10 @@ transport:
 provisioner:
   name: dokken
   product_name: chef
-  enforce_idempotency: true
-  multiple_converge: 2
+  # Uncomment when testing idempotency
+  # The add & delete key in dummy_key.rb breaks this right now (on purpose)
+  # enforce_idempotency: true
+  # multiple_converge: 2
   solo_rb:
     treat_deprecation_warnings_as_errors: true
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -15,16 +15,15 @@ provisioner:
 verifier: inspec
 
 platforms:
-  - name: amazon-linux
-    driver_config:
-      box: mvbcoding/awslinux
-  - name: centos-6
+  - name: amazon-linux-2
   - name: centos-7
-  - name: debian-8
+  - name: centos-8
   - name: debian-9
-  - name: fedora-28
+  - name: debian-10
+  - name: fedora-32
   - name: ubuntu-16.04
   - name: ubuntu-18.04
+  - name: ubuntu-20.04
 
 suites:
   - name: default

--- a/resources/key.rb
+++ b/resources/key.rb
@@ -62,9 +62,15 @@ property :key_file, String,
 property :key_fingerprint, String,
          description: 'Key finger print. Used to identify when deleting keys using the :delete action'
 
-# Only Ubuntu supports the pinetree_mode. And requires it
+# Only Ubuntu > 16.04 supports the pinetree_mode. And requires it
 property :pinentry_mode, [String, FalseClass],
-default: lazy { platform?('ubuntu') ? 'loopback' : false },
+default: lazy {
+  if platform?('ubuntu') && node['platform_version'].to_f > 16.04
+    'loopback'
+  else
+    false
+  end
+},
 description: 'Pinentry mode. Set to loopback on Ubuntu and False (off) for all other platforms.'
 
 property :batch, [true, false],


### PR DESCRIPTION
Now that enforce_idempotency works with dokken, this is breaking tests for
dokken.

Signed-off-by: Lance Albertson <lance@osuosl.org>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
