### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
           - "ubuntu-2004"
           - "ubuntu-2204"
           - "ubuntu-2404"
-          - "ubuntu-2410"
         suite:
           - "default"
       fail-fast: false

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/fixtures/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+name 'gpg'
+
+run_list 'test::default'
+
+cookbook 'gpg', path: '.'
+cookbook 'yum-epel', git: 'https://github.com/sous-chefs/yum-epel.git', branch: 'main'
+cookbook 'test', path: './test/fixtures/cookbooks/test'
+
+Dir.children('./test/fixtures/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,7 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/documentation/resource/key.md
+++ b/documentation/resource/key.md
@@ -2,8 +2,10 @@
 
 ## Properties
 
+<!-- markdownlint-disable MD060 -->
+
 | Property                   | Ruby Type       | Default                                | Description                                                                                                |
-|----------------------------|-----------------|----------------------------------------|------------------------------------------------------------------------------------------------------------|
+| --- | --- | --- | --- |
 | `batch_name`               | String          |                                        | Name of  the key/batch to generate.                                                                        |
 | `override_default_keyring` | [true, false]   | `false`                                | Set to true if you want to override the pubring_file and secring_file locations.                           |
 | `pubring_file`             | String          |                                        | Public keyring file location (override_default_keyring must be set to true or this option will be ignored) |
@@ -24,6 +26,8 @@
 | `pinentry_mode`            | [String, false] | `loopback` if Ubuntu or False          | Pinentry mode. Set to loopback on Ubuntu and False (off) for all other platforms.                          |
 | `batch`                    | [true, false]   | true                                   | Turn batch mode on or off when generating keys                                                              |
 | `keyserver`                | String          |                                        | Keyserver to use when importing keys                                                                       |
+
+<!-- markdownlint-enable MD060 -->
 
 ## Actions
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -105,7 +105,3 @@ platforms:
   - name: ubuntu-24.04
     driver:
       image: dokken/ubuntu-24.04
-
-  - name: ubuntu-24.10
-    driver:
-      image: dokken/ubuntu-24.10

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -35,4 +35,3 @@ platforms:
   - name: ubuntu-20.04
   - name: ubuntu-22.04
   - name: ubuntu-24.04
-  - name: ubuntu-24.10

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -39,7 +39,7 @@ module Gpg
           minor = version_match[2].to_i
 
           # GPG 2.4.0+ uses keyboxd by default
-          @uses_keyboxd = (major > 2 || (major == 2 && minor >= 4))
+          @uses_keyboxd = major > 2 || (major == 2 && minor >= 4)
           Chef::Log.debug("GPG version #{major}.#{minor} detected, keyboxd: #{@uses_keyboxd}")
           return @uses_keyboxd
         end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,4 +1,5 @@
 unified_mode true
+provides :gpg_install
 
 property :name, String, default: ''
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -4,7 +4,9 @@ provides :gpg_install
 property :name, String, default: ''
 
 action :install do
-  include_recipe 'yum-epel' if platform_family?('rhel', 'amazon')
+  yum_epel 'default' do
+    only_if { platform_family?('rhel', 'amazon') }
+  end
 
   # On Amazon Linux 2023, gnupg2-minimal conflicts with gnupg2
   # Use --allowerasing to replace it

--- a/resources/key.rb
+++ b/resources/key.rb
@@ -1,6 +1,7 @@
 require 'shellwords'
 
 unified_mode true
+provides :gpg_key
 
 property :batch_name, String,
          name_property: true,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update Copilot setup to install Chef Workstation 8.0.4 and run chef install Policyfile.rb
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- kitchen list
- /opt/chef-workstation/embedded/bin/rspec --format progress